### PR TITLE
support snapshot option 'invalidate_hard_deletes'

### DIFF
--- a/dbt/include/exasol/macros/materializations/snapshot.sql
+++ b/dbt/include/exasol/macros/materializations/snapshot.sql
@@ -25,6 +25,7 @@
             {{ strategy.unique_key }} as dbt_unique_key
 
         from {{ target_relation | upper }} tgt
+        where dbt_valid_to is null
 
     ),
 
@@ -108,7 +109,31 @@
 
     )
 
+    {%- if strategy.invalidate_hard_deletes -%}
+    ,
+
+    deletes as (
+
+        select
+            'delete' as dbt_change_type,
+            snapshotted_data.dbt_scd_id,
+            {{ snapshot_get_time() }} as dbt_valid_to
+
+        from snapshotted_data
+        left join source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+        where
+            snapshotted_data.dbt_valid_to is null
+            and source_data.dbt_unique_key is null
+    )
+    {%- endif %}
+
     select * from updates
+
+    {%- if strategy.invalidate_hard_deletes %}
+    union all
+    select * from deletes
+
+    {%- endif %}
 
 {%- endmacro %}
 

--- a/dbt/include/exasol/macros/materializations/snapshot.sql
+++ b/dbt/include/exasol/macros/materializations/snapshot.sql
@@ -132,7 +132,6 @@
     {%- if strategy.invalidate_hard_deletes %}
     union all
     select * from deletes
-
     {%- endif %}
 
 {%- endmacro %}

--- a/dbt/include/exasol/macros/materializations/snapshot_merge.sql
+++ b/dbt/include/exasol/macros/materializations/snapshot_merge.sql
@@ -6,14 +6,15 @@
     on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id
 
     when matched
-     --and DBT_INTERNAL_DEST.dbt_valid_to is null
-     --and DBT_INTERNAL_SOURCE.dbt_change_type = 'update'
         then update
         set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
+        where
+            DBT_INTERNAL_DEST.dbt_valid_to is null
+            and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
 
     when not matched
-     --and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'
-        then insert ({{ insert_cols_csv |upper }})
+        then insert ({{ insert_cols_csv | upper }})
         values ({{ insert_cols_csv | upper}})
+        where DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'
     ;
 {% endmacro %}

--- a/dbt/include/exasol/macros/materializations/strategies.sql
+++ b/dbt/include/exasol/macros/materializations/strategies.sql
@@ -31,6 +31,7 @@
 {% macro exasol__snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}
     {% set check_cols_config = config['check_cols'] %}
     {% set primary_key = config['unique_key'] %}
+    {% set invalidate_hard_deletes = config['invalidate_hard_deletes'] %}
     {% set select_current_time -%}
         select {{ snapshot_get_time() }} as snapshot_start
     {%- endset %}
@@ -73,6 +74,7 @@
         "unique_key": primary_key,
         "updated_at": updated_at,
         "row_changed": row_changed_expr,
-        "scd_id": scd_id_expr
+        "scd_id": scd_id_expr,
+        "invalidate_hard_deletes": invalidate_hard_deletes
     }) %}
 {% endmacro %}


### PR DESCRIPTION
This PR:
1. adds the option to `invalidate_hard_deletes` which marks records missing in the source as deleted in the snapshot
2. adapts snapshot_merge.sql so that it follows the same structure as the file in dbt-core

## Tests
I tested snapshots manually both with and without the new configuration option `invalidate_hard_deletes` enabled.
```
{{
    config(
      unique_key='id',
      target_schema='test_schema',
      strategy='check',
      invalidate_hard_deletes=True,
      check_cols=[ 'val' ]
    )
}}
```

Step 0: One row (`id = 1`) is present in the source
![Screenshot 2022-05-31 at 3 09 38 PM](https://user-images.githubusercontent.com/217980/171170438-c713aa71-3b32-47c4-b630-8febca62cd15.png)

Step 1: A second row (`id = 2`) is present in the source
![Screenshot 2022-05-31 at 3 11 03 PM](https://user-images.githubusercontent.com/217980/171170527-f8087b66-f6d0-4d2d-b6d4-4523dbaf1c29.png)

Step 2: The first row (`id = 1`) is deleted in the source. Thus, valid_to is set by the `dbt snapshot` run
![Screenshot 2022-05-31 at 5 38 56 PM](https://user-images.githubusercontent.com/217980/171170867-052c7fb2-d3ff-461a-bcd3-73a000f4aaae.png)

Step 3: The first row (`id = 1`) appears again in the source. Thus, it is added to the snapshot as a valid row
![Screenshot 2022-05-31 at 5 39 56 PM](https://user-images.githubusercontent.com/217980/171171000-3bb9452f-cd30-4f3d-81bf-a1f329c52949.png)

Step 4: The second row (`id = 2`) changes its value to `val = 'v2'`. Thus, the old record is is marked as valid_until und a new row for the current value is appended to the snapshot.
![Screenshot 2022-05-31 at 5 40 54 PM](https://user-images.githubusercontent.com/217980/171171078-4a8f8a4b-d643-4bbe-9b78-61f872e0f703.png)

Thus it has been demonstrated that this PR satisfies the following cases:
1. The existing functionality of tracking changes of rows over time has not been changed
2. Hard deletes in the source are tracked as well if the option is enabled. This means that if a row does not appear in the source data, it will be marked as deleted in the snapshot
3. Once deleted, rows can re-appear in the source and their re-appearance will be tracked in the snapshot as well. 


## Background
This PR aims to follow the code from dbt-core as seen [here](https://github.com/dbt-labs/dbt-core/pull/2749/) and [here](https://github.com/dbt-labs/dbt-core/pull/2821/) 